### PR TITLE
Add interview prep feature with daily automated questions

### DIFF
--- a/db.py
+++ b/db.py
@@ -40,6 +40,22 @@ class DataBase:
                 user_last_name TEXT,
                 text TEXT
             );
+            CREATE TABLE IF NOT EXISTS interview_questions(
+                id INTEGER PRIMARY KEY,
+                category TEXT NOT NULL,
+                question TEXT NOT NULL,
+                is_used INTEGER DEFAULT 0,
+                date_added TEXT DEFAULT (datetime('now')),
+                date_used TEXT
+            );
+            CREATE TABLE IF NOT EXISTS daily_questions(
+                id INTEGER PRIMARY KEY,
+                date TEXT NOT NULL UNIQUE,
+                question_id INTEGER,
+                question_text TEXT,
+                category TEXT,
+                FOREIGN KEY (question_id) REFERENCES interview_questions(id)
+            );
             """
             )
         return True
@@ -169,6 +185,100 @@ class DataBase:
             GROUP BY faculty
             ORDER BY score DESC;
             """
+            )
+        return self.cursor.fetchall()
+
+    def populate_interview_questions(self, questions_list):
+        """Populates the interview_questions table with initial questions"""
+        with self.connection:
+            for category, question in questions_list:
+                self.cursor.execute(
+                    """
+                    INSERT OR IGNORE INTO interview_questions (category, question)
+                    VALUES (?, ?);
+                    """,
+                    (category, question)
+                )
+
+    def get_random_unused_question(self, category=None):
+        """Gets a random unused interview question, optionally filtered by category"""
+        query = """
+            SELECT id, category, question 
+            FROM interview_questions 
+            WHERE is_used = 0
+        """
+        params = []
+        
+        if category:
+            query += " AND category = ?"
+            params.append(category)
+            
+        query += " ORDER BY RANDOM() LIMIT 1;"
+        
+        with self.connection:
+            self.cursor.execute(query, params)
+        return self.cursor.fetchone()
+
+    def mark_question_as_used(self, question_id):
+        """Marks a question as used"""
+        with self.connection:
+            self.cursor.execute(
+                """
+                UPDATE interview_questions 
+                SET is_used = 1, date_used = datetime('now')
+                WHERE id = ?;
+                """,
+                (question_id,)
+            )
+
+    def save_daily_question(self, date, question_id, question_text, category):
+        """Saves the daily question for tracking"""
+        with self.connection:
+            self.cursor.execute(
+                """
+                INSERT OR REPLACE INTO daily_questions 
+                (date, question_id, question_text, category)
+                VALUES (?, ?, ?, ?);
+                """,
+                (date, question_id, question_text, category)
+            )
+
+    def get_daily_question(self, date):
+        """Gets the daily question for a specific date"""
+        with self.connection:
+            self.cursor.execute(
+                """
+                SELECT question_text, category 
+                FROM daily_questions 
+                WHERE date = ?;
+                """,
+                (date,)
+            )
+        return self.cursor.fetchone()
+
+    def reset_all_questions(self):
+        """Resets all questions to unused state (for cycling through questions again)"""
+        with self.connection:
+            self.cursor.execute(
+                """
+                UPDATE interview_questions 
+                SET is_used = 0, date_used = NULL;
+                """
+            )
+
+    def get_question_stats(self):
+        """Gets statistics about interview questions"""
+        with self.connection:
+            self.cursor.execute(
+                """
+                SELECT 
+                    category,
+                    COUNT(*) as total,
+                    SUM(is_used) as used,
+                    COUNT(*) - SUM(is_used) as remaining
+                FROM interview_questions 
+                GROUP BY category;
+                """
             )
         return self.cursor.fetchall()
 

--- a/interview_questions.py
+++ b/interview_questions.py
@@ -1,0 +1,129 @@
+"""
+Interview questions for behavioral, soft skill, and culture fit assessments.
+These questions are commonly asked in IT industry interviews for junior positions.
+"""
+
+BEHAVIORAL_QUESTIONS = [
+    "Tell me about a time when you had to learn a new technology quickly. How did you approach it?",
+    "Describe a situation where you made a mistake in your code. How did you handle it?",
+    "Tell me about a time when you had to work with a difficult team member. How did you resolve it?",
+    "Describe a project you're particularly proud of. What made it special?",
+    "Tell me about a time when you received constructive criticism. How did you respond?",
+    "Describe a situation where you had to meet a tight deadline. How did you manage it?",
+    "Tell me about a time when you had to explain a technical concept to a non-technical person.",
+    "Describe a situation where you had to adapt to a major change in project requirements.",
+    "Tell me about a time when you took initiative to improve a process or solve a problem.",
+    "Describe a situation where you had to collaborate with people from different departments.",
+    "Tell me about a time when you disagreed with your supervisor or team lead. How did you handle it?",
+    "Describe a project where you had to work with incomplete or unclear requirements.",
+    "Tell me about a time when you had to balance multiple priorities. How did you manage them?",
+    "Describe a situation where you had to learn from failure. What did you take away from it?",
+    "Tell me about a time when you went above and beyond what was expected of you.",
+    "Describe a situation where you had to give feedback to a peer. How did you approach it?",
+    "Tell me about a time when you had to work under pressure. How did you handle the stress?",
+    "Describe a situation where you had to convince others to adopt your technical solution.",
+    "Tell me about a time when you had to deal with ambiguous requirements. How did you proceed?",
+    "Describe a project where you had to work independently with minimal guidance."
+]
+
+SOFT_SKILL_QUESTIONS = [
+    "How do you stay updated with the latest technology trends and developments?",
+    "Describe your approach to debugging a complex problem.",
+    "How do you prioritize tasks when everything seems urgent?",
+    "What strategies do you use to improve your coding skills?",
+    "How do you handle situations where you don't know the answer to a technical question?",
+    "Describe your process for code review. What do you look for?",
+    "How do you ensure code quality in your projects?",
+    "What's your approach to learning a new programming language or framework?",
+    "How do you handle interruptions while working on complex tasks?",
+    "Describe your method for breaking down large projects into manageable tasks.",
+    "How do you stay organized when working on multiple projects simultaneously?",
+    "What's your approach to writing documentation for your code?",
+    "How do you handle situations where you need to estimate time for unfamiliar tasks?",
+    "Describe your process for testing your code before deployment.",
+    "How do you approach pair programming or collaborative coding sessions?",
+    "What strategies do you use to maintain focus during long coding sessions?",
+    "How do you handle technical debt in your projects?",
+    "Describe your approach to choosing between multiple technical solutions.",
+    "How do you keep track of your learning goals and progress?",
+    "What's your process for preparing for technical interviews or coding challenges?"
+]
+
+CULTURE_FIT_QUESTIONS = [
+    "What motivates you to work in the tech industry?",
+    "How do you prefer to receive feedback on your work?",
+    "Describe your ideal work environment and team dynamics.",
+    "What does work-life balance mean to you?",
+    "How do you handle stress and prevent burnout in a fast-paced environment?",
+    "What role do you typically play in team projects?",
+    "How do you contribute to a positive team culture?",
+    "What's your approach to continuous learning and professional development?",
+    "How do you handle conflicts or disagreements in a professional setting?",
+    "What values are most important to you in a workplace?",
+    "How do you prefer to communicate with team members and stakeholders?",
+    "Describe a time when you had to adapt to a company's culture or values.",
+    "What makes you excited about coming to work each day?",
+    "How do you handle situations where you need help or mentorship?",
+    "What's your approach to giving and receiving constructive feedback?",
+    "How do you contribute to knowledge sharing within a team?",
+    "What type of projects or challenges energize you the most?",
+    "How do you handle ambiguity and uncertainty in your work?",
+    "What's your philosophy on work ownership and accountability?",
+    "How do you maintain enthusiasm during routine or less exciting tasks?",
+    "What role does diversity and inclusion play in your ideal workplace?",
+    "How do you approach building relationships with new team members?",
+    "What's your preferred style of leadership and being led?",
+    "How do you handle situations where company priorities change frequently?",
+    "What aspects of company culture matter most to you when choosing an employer?"
+]
+
+IT_SPECIFIC_QUESTIONS = [
+    "How do you approach working with legacy code?",
+    "Describe your experience with version control and collaborative development.",
+    "How do you stay current with security best practices in your development work?",
+    "What's your approach to writing maintainable and scalable code?",
+    "How do you handle situations where business requirements conflict with technical best practices?",
+    "Describe your experience working in an Agile/Scrum environment.",
+    "How do you approach performance optimization in your applications?",
+    "What's your philosophy on code comments and documentation?",
+    "How do you handle technical discussions with non-technical stakeholders?",
+    "Describe your approach to choosing technologies for a new project.",
+    "How do you balance speed of delivery with code quality?",
+    "What's your experience with different development methodologies?",
+    "How do you approach mobile-first or responsive design challenges?",
+    "Describe your experience with database design and optimization.",
+    "How do you handle situations where you need to refactor existing code?",
+    "What's your approach to API design and integration?",
+    "How do you ensure accessibility in your applications?",
+    "Describe your experience with different testing strategies (unit, integration, etc.).",
+    "How do you approach monitoring and logging in production applications?",
+    "What's your philosophy on technical innovation vs. proven solutions?"
+]
+
+def get_all_questions():
+    """Returns all interview questions as a single list with categories."""
+    questions = []
+    
+    for q in BEHAVIORAL_QUESTIONS:
+        questions.append(("behavioral", q))
+    
+    for q in SOFT_SKILL_QUESTIONS:
+        questions.append(("soft_skill", q))
+        
+    for q in CULTURE_FIT_QUESTIONS:
+        questions.append(("culture_fit", q))
+        
+    for q in IT_SPECIFIC_QUESTIONS:
+        questions.append(("it_specific", q))
+    
+    return questions
+
+def get_questions_by_category(category):
+    """Returns questions filtered by category."""
+    category_map = {
+        "behavioral": BEHAVIORAL_QUESTIONS,
+        "soft_skill": SOFT_SKILL_QUESTIONS,
+        "culture_fit": CULTURE_FIT_QUESTIONS,
+        "it_specific": IT_SPECIFIC_QUESTIONS
+    }
+    return category_map.get(category, [])

--- a/interview_scheduler.py
+++ b/interview_scheduler.py
@@ -1,0 +1,174 @@
+"""
+Interview question scheduler for daily automated posting
+"""
+import random
+from datetime import datetime, timedelta
+from threading import Timer
+
+from config import logger, settings
+from db import DataBase
+from interview_questions import get_all_questions
+
+
+def post_daily_interview_question(bot):
+    """Posts a random interview question to the chat"""
+    try:
+        today = datetime.now().strftime('%Y-%m-%d')
+        db = DataBase()
+        
+        # Check if we already posted a question today
+        existing_question = db.get_daily_question(today)
+        if existing_question:
+            logger.info(f"Daily question already posted for {today}")
+            db.close()
+            return
+        
+        # Get a random unused question
+        question_data = db.get_random_unused_question()
+        
+        if not question_data:
+            # If no unused questions, reset all questions and try again
+            logger.info("No unused questions left, resetting all questions")
+            db.reset_all_questions()
+            question_data = db.get_random_unused_question()
+        
+        if question_data:
+            question_id, category, question_text = question_data
+            
+            # Mark question as used
+            db.mark_question_as_used(question_id)
+            
+            # Save as daily question
+            db.save_daily_question(today, question_id, question_text, category)
+            
+            # Format and send message
+            category_emoji = {
+                "behavioral": "🧠",
+                "soft_skill": "💪", 
+                "culture_fit": "🏢",
+                "it_specific": "💻"
+            }
+            
+            category_names = {
+                "behavioral": "Поведенческий",
+                "soft_skill": "Навыки", 
+                "culture_fit": "Культура компании",
+                "it_specific": "IT-специфичный"
+            }
+            
+            emoji = category_emoji.get(category, "❓")
+            category_name = category_names.get(category, category.title())
+            
+            message = f"Сегодняшний вопрос для подготовки к собеседованию: {question_text} {emoji} Подумай и потренируйся отвечать вслух!"
+            
+            # Send to the main chat
+            if hasattr(settings, 'CHAT_ALERT') and settings.CHAT_ALERT:
+                bot.send_message(settings.CHAT_ALERT, message, parse_mode="Markdown")
+                logger.info(f"Posted daily interview question: {category} - {question_text[:50]}...")
+            else:
+                logger.warning("CHAT_ALERT not configured, couldn't send daily question")
+                
+        else:
+            logger.error("Could not get any interview question from database")
+            
+        db.close()
+        
+    except Exception as e:
+        logger.error(f"Error posting daily interview question: {e}")
+
+
+def schedule_daily_questions(bot):
+    """Schedules daily interview questions"""
+    def check_and_post():
+        """Check if it's time to post and schedule next check"""
+        try:
+            now = datetime.now()
+            
+            # Post at 11:00 AM every day
+            target_hour = 11
+            target_minute = 0
+            
+            # Check if it's the right time (within 1 minute window)
+            if now.hour == target_hour and now.minute == target_minute:
+                post_daily_interview_question(bot)
+            
+            # Schedule next check in 60 seconds
+            timer = Timer(60.0, check_and_post)
+            timer.daemon = True
+            timer.start()
+            
+        except Exception as e:
+            logger.error(f"Error in interview question scheduler: {e}")
+            # Reschedule even if there's an error
+            timer = Timer(60.0, check_and_post)
+            timer.daemon = True
+            timer.start()
+    
+    # Start the scheduler
+    check_and_post()
+    logger.info("Interview question scheduler started")
+
+
+def initialize_questions_database():
+    """Initialize the database with interview questions if it's empty"""
+    try:
+        db = DataBase()
+        
+        # Check if questions are already loaded
+        stats = db.get_question_stats()
+        if stats:
+            total_questions = sum(stat[1] for stat in stats)
+            logger.info(f"Database already has {total_questions} interview questions")
+            db.close()
+            return
+        
+        # Load all questions
+        questions = get_all_questions()
+        db.populate_interview_questions(questions)
+        
+        logger.info(f"Loaded {len(questions)} interview questions into database")
+        db.close()
+        
+    except Exception as e:
+        logger.error(f"Error initializing questions database: {e}")
+
+
+def get_question_statistics():
+    """Get statistics about interview questions"""
+    try:
+        db = DataBase()
+        stats = db.get_question_stats()
+        db.close()
+        
+        if not stats:
+            return "Нет данных о вопросах для собеседования"
+        
+        message = "📊 **Статистика вопросов для собеседования:**\n\n"
+        
+        total_all = 0
+        used_all = 0
+        
+        for category, total, used, remaining in stats:
+            category_names = {
+                "behavioral": "Поведенческие",
+                "soft_skill": "Навыки", 
+                "culture_fit": "Культура компании",
+                "it_specific": "IT-специфичные"
+            }
+            
+            category_name = category_names.get(category, category.title())
+            message += f"**{category_name}:**\n"
+            message += f"  • Всего: {total}\n"
+            message += f"  • Использовано: {used}\n"
+            message += f"  • Осталось: {remaining}\n\n"
+            
+            total_all += total
+            used_all += used
+        
+        message += f"**Итого:** {total_all} вопросов ({used_all} использовано, {total_all - used_all} осталось)"
+        
+        return message
+        
+    except Exception as e:
+        logger.error(f"Error getting question statistics: {e}")
+        return "Ошибка при получении статистики"

--- a/main.py
+++ b/main.py
@@ -10,6 +10,9 @@ from config import logger, settings
 from db import DataBase
 from health_endpoint import flask_thread, shutdown_event
 from utilities import choose_noun_case, get_time
+from interview_scheduler import (initialize_questions_database, schedule_daily_questions, 
+                                get_question_statistics, post_daily_interview_question)
+from interview_questions import get_questions_by_category
 
 ADMIN_ID = settings.ADMIN_ID
 INSPECT_ID = settings.INSPECT_ID
@@ -22,6 +25,7 @@ bot.set_my_commands(
         telebot.types.BotCommand("/read_link", "Что там за ссылкой?"),
         telebot.types.BotCommand("/house_points", "Баллы факультетов"),
         telebot.types.BotCommand("/positions", "IT jobs in Netherlands"),
+        telebot.types.BotCommand("/interview", "Вопрос для собеседования"),
     ]
 )
 
@@ -31,6 +35,8 @@ bot.set_my_commands(
         telebot.types.BotCommand("/show_logs", "Показать логи"),
         telebot.types.BotCommand("/house_points", "Баллы факультетов"),
         telebot.types.BotCommand("/positions", "IT jobs in Netherlands"),
+        telebot.types.BotCommand("/interview", "Вопрос для собеседования"),
+        telebot.types.BotCommand("/interview_stats", "Статистика вопросов"),
     ],
     scope=telebot.types.BotCommandScopeChat(INSPECT_ID),
 )
@@ -42,6 +48,7 @@ if not settings.DEBUG:
                 telebot.types.BotCommand("/read_link", "Что там за ссылкой?"),
                 telebot.types.BotCommand("/house_points", "Баллы факультетов"),
                 telebot.types.BotCommand("/positions", "IT jobs in Netherlands"),
+                telebot.types.BotCommand("/interview", "Вопрос для собеседования"),
             ],
             scope=telebot.types.BotCommandScopeChat(ADMIN_ID),
         )
@@ -142,6 +149,111 @@ def get_positions(message):
         bot.send_message(
             message.chat.id,
             "❌ Sorry, there was an error fetching job positions. Please try again later.",
+            parse_mode="Markdown"
+        )
+
+
+@bot.message_handler(commands=["interview"])
+def get_interview_question(message):
+    """Gets a random interview question for practice."""
+    try:
+        # Parse optional category from command
+        text_parts = message.text.split()
+        category = None
+        
+        if len(text_parts) > 1:
+            category_map = {
+                "behavioral": "behavioral",
+                "поведенческий": "behavioral", 
+                "soft": "soft_skill",
+                "навыки": "soft_skill",
+                "culture": "culture_fit",
+                "культура": "culture_fit",
+                "it": "it_specific",
+                "ит": "it_specific"
+            }
+            category = category_map.get(text_parts[1].lower())
+        
+        db = DataBase()
+        question_data = db.get_random_unused_question(category)
+        
+        if not question_data:
+            # If no unused questions, get any random question
+            if category:
+                # For specific category, get random from that category
+                questions = get_questions_by_category(category)
+                if questions:
+                    import random
+                    question_text = random.choice(questions)
+                    category_display = category
+                else:
+                    question_text = "Не найдено вопросов для данной категории."
+                    category_display = category
+            else:
+                # Reset all and try again
+                db.reset_all_questions()
+                question_data = db.get_random_unused_question()
+                if question_data:
+                    _, category_display, question_text = question_data
+                else:
+                    question_text = "Не удалось получить вопрос для собеседования."
+                    category_display = "unknown"
+        else:
+            question_id, category_display, question_text = question_data
+            # Don't mark as used for manual requests, only for daily posts
+            
+        db.close()
+        
+        # Format message
+        category_emoji = {
+            "behavioral": "🧠",
+            "soft_skill": "💪", 
+            "culture_fit": "🏢",
+            "it_specific": "💻"
+        }
+        
+        category_names = {
+            "behavioral": "Поведенческий",
+            "soft_skill": "Навыки", 
+            "culture_fit": "Культура компании",
+            "it_specific": "IT-специфичный"
+        }
+        
+        emoji = category_emoji.get(category_display, "❓")
+        category_name = category_names.get(category_display, category_display.title())
+        
+        response = f"Вопрос для собеседования: {question_text} {emoji} Подумай и потренируйся отвечать вслух!\n\n"
+        response += "📝 *Доступные категории: behavioral, soft, culture, it*"
+        
+        bot.send_message(message.chat.id, response, parse_mode="Markdown")
+        
+    except Exception as e:
+        logger.error(f"Error in interview command: {e}")
+        bot.send_message(
+            message.chat.id,
+            "❌ Произошла ошибка при получении вопроса. Попробуйте позже.",
+            parse_mode="Markdown"
+        )
+
+
+@bot.message_handler(commands=["interview_stats"])
+def get_interview_stats(message):
+    """Shows interview question statistics (admin only)."""
+    if message.from_user.id == INSPECT_ID or message.from_user.id == ADMIN_ID:
+        try:
+            stats_message = get_question_statistics()
+            bot.send_message(message.chat.id, stats_message, parse_mode="Markdown")
+        except Exception as e:
+            logger.error(f"Error getting interview stats: {e}")
+            bot.send_message(
+                message.chat.id,
+                "❌ Ошибка при получении статистики.",
+                parse_mode="Markdown"
+            )
+    else:
+        bot.send_message(
+            message.chat.id,
+            "❌ Эта команда доступна только администраторам.",
             parse_mode="Markdown"
         )
 
@@ -349,10 +461,20 @@ def monitoring_friday_talks():
 
 
 if __name__ == "__main__":
+    # Initialize database
     db = DataBase()
     db.create_database()
     db.close()
+    
+    # Initialize interview questions
+    initialize_questions_database()
+    
+    # Start background services
     flask_thread.start()
+    
+    # Start interview question scheduler
+    schedule_daily_questions(bot)
+    
     # monitoring_friday_talks()
     try:
         bot.infinity_polling(timeout=10, long_polling_timeout=5)

--- a/test_interview_feature.py
+++ b/test_interview_feature.py
@@ -1,0 +1,131 @@
+"""
+Simple test script for the interview feature
+"""
+import os
+import tempfile
+from interview_questions import get_all_questions, get_questions_by_category
+
+def test_question_loading():
+    """Test that questions are loaded correctly"""
+    questions = get_all_questions()
+    print(f"✓ Total questions loaded: {len(questions)}")
+    
+    # Test categories
+    categories = ["behavioral", "soft_skill", "culture_fit", "it_specific"]
+    for category in categories:
+        cat_questions = get_questions_by_category(category)
+        print(f"✓ {category}: {len(cat_questions)} questions")
+    
+    return len(questions) > 0
+
+def test_database_operations():
+    """Test database operations with a temporary database"""
+    import sqlite3
+    from interview_questions import get_all_questions
+    
+    # Create temporary database
+    with tempfile.NamedTemporaryFile(suffix='.db', delete=False) as tmp:
+        db_path = tmp.name
+    
+    try:
+        # Create database schema
+        conn = sqlite3.connect(db_path)
+        cursor = conn.cursor()
+        
+        cursor.executescript("""
+            CREATE TABLE interview_questions(
+                id INTEGER PRIMARY KEY,
+                category TEXT NOT NULL,
+                question TEXT NOT NULL,
+                is_used INTEGER DEFAULT 0,
+                date_added TEXT DEFAULT (datetime('now')),
+                date_used TEXT
+            );
+            CREATE TABLE daily_questions(
+                id INTEGER PRIMARY KEY,
+                date TEXT NOT NULL UNIQUE,
+                question_id INTEGER,
+                question_text TEXT,
+                category TEXT,
+                FOREIGN KEY (question_id) REFERENCES interview_questions(id)
+            );
+        """)
+        
+        # Load questions
+        questions = get_all_questions()
+        for category, question in questions:
+            cursor.execute(
+                "INSERT INTO interview_questions (category, question) VALUES (?, ?)",
+                (category, question)
+            )
+        
+        conn.commit()
+        
+        # Test random selection
+        cursor.execute("""
+            SELECT id, category, question 
+            FROM interview_questions 
+            WHERE is_used = 0 
+            ORDER BY RANDOM() 
+            LIMIT 1
+        """)
+        
+        result = cursor.fetchone()
+        if result:
+            print(f"✓ Random question retrieved: {result[1]} - {result[2][:50]}...")
+        else:
+            print("✗ No questions found")
+            return False
+            
+        # Test category filtering
+        cursor.execute("""
+            SELECT COUNT(*) 
+            FROM interview_questions 
+            WHERE category = 'behavioral'
+        """)
+        
+        count = cursor.fetchone()[0]
+        print(f"✓ Behavioral questions in DB: {count}")
+        
+        conn.close()
+        
+        # Clean up
+        os.unlink(db_path)
+        
+        return True
+        
+    except Exception as e:
+        print(f"✗ Database test failed: {e}")
+        if os.path.exists(db_path):
+            os.unlink(db_path)
+        return False
+
+def main():
+    """Run all tests"""
+    print("Testing Interview Feature Implementation")
+    print("=" * 40)
+    
+    success = True
+    
+    print("\n1. Testing question loading...")
+    success &= test_question_loading()
+    
+    print("\n2. Testing database operations...")
+    success &= test_database_operations()
+    
+    print("\n" + "=" * 40)
+    if success:
+        print("✓ All tests passed! Interview feature is ready to use.")
+        print("\nFeature Summary:")
+        print("- 🎯 Daily automated questions at 9:00 AM")
+        print("- 🔤 Manual /interview command with category support")
+        print("- 📊 Admin statistics with /interview_stats")
+        print("- 🗃️ Database tracking of used questions")
+        print("- 🔄 Automatic reset when all questions are used")
+    else:
+        print("✗ Some tests failed. Please check the implementation.")
+    
+    return success
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION


# Description
- Add comprehensive interview question database (85 questions)
- Implement daily automated posting at 11:00 AM
- Add manual /interview command with category support
- Include database tables for question tracking
- Add admin statistics with /interview_stats command
- Support question cycling when all are used
- Include behavioral, soft skill, culture fit, and IT-specific categories

Fixes # (issue)



- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

